### PR TITLE
Corrected missing credential id bug and permission bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ curl \
 
 You should see a JSON with the exported content.
 You can also invoke the endpoint for other realms by replacing `master` with the realm name in the above URL.
+Note that only an admin user in the master realm can call functions from this module.
 
 
 ## Testing

--- a/src/main/java/io/cloudtrust/keycloak/export/dto/BetterCredentialRepresentation.java
+++ b/src/main/java/io/cloudtrust/keycloak/export/dto/BetterCredentialRepresentation.java
@@ -1,0 +1,15 @@
+package io.cloudtrust.keycloak.export.dto;
+
+import org.keycloak.representations.idm.CredentialRepresentation;
+
+public class BetterCredentialRepresentation extends CredentialRepresentation {
+
+    private String id;
+
+    public void setId(String id) {
+        this.id = id;
+    }
+    public String getId(){
+        return id;
+    }
+}


### PR DESCRIPTION
- Added credential IDs that were missing during export (the value is missing in keycloak's CredentialRepresentation)
- Corrected handling of permissions. Now only an admin in the master realm can export realms due to the sensitive nature of the information that may be contained in the exports.
- Added a couple of unit tests to better test the handling of permissions