### PR TITLE
Correction to allow strategies to be used with the improved import

### DIFF
--- a/src/main/java/io/cloudtrust/keycloak/export/ExportResourceProvider.java
+++ b/src/main/java/io/cloudtrust/keycloak/export/ExportResourceProvider.java
@@ -5,6 +5,7 @@ import io.cloudtrust.keycloak.export.dto.BetterRealmRepresentation;
 import org.jboss.logging.Logger;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.credential.CredentialModel;
+import org.keycloak.exportimport.Strategy;
 import org.keycloak.exportimport.util.ExportUtils;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.jose.jws.JWSInputException;
@@ -169,7 +170,7 @@ public class ExportResourceProvider implements RealmResourceProvider {
             AdminAuth auth = authenticateRealmAdminRequest(headers, uriInfo);
             AdminPermissions.realms(session, auth).requireCreateRealm();
 
-            RealmModel realm = ImportExportUtils.importRealm(session, keycloak, rep);
+            RealmModel realm = ImportExportUtils.importRealm(session, keycloak, rep, null, false);
             grantPermissionsToRealmCreator(auth, realm);
 
             URI location = AdminRoot.realmsUrl(session.getContext().getUri()).path(realm.getName()).build();

--- a/src/main/java/io/cloudtrust/keycloak/export/SingleFileImportProvider.java
+++ b/src/main/java/io/cloudtrust/keycloak/export/SingleFileImportProvider.java
@@ -76,8 +76,7 @@ public class SingleFileImportProvider implements ImportProvider {
     }
 
     private void importRealm(KeycloakSession session, BetterRealmRepresentation realm, Strategy strategy) {
-        logger.infof("Importing realm %s (strategy %s ignored)", realm.getRealm(), strategy);
-        ImportExportUtils.importRealm(session, null, realm);
+        ImportExportUtils.importRealm(session, null, realm, strategy, false);
     }
 
     private BetterRealmRepresentation getMasterRealm() throws IOException {


### PR DESCRIPTION
This corrects an oversight that prevented the import module from overwriting a realm, which is necessary when importing master, for example.